### PR TITLE
feat: Enable continuous 5-minute execution cycle for the bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Binance Trading Signal Bot
 
-This Python bot generates trading signals (Long/Short/Hold) for specified cryptocurrency pairs on Binance. It uses a common trading strategy based on Simple Moving Average (SMA) crossovers confirmed by the Relative Strength Index (RSI).
+This Python bot continuously monitors specified cryptocurrency pairs on Binance, generating trading signals (Long/Short/Hold) by evaluating market data every 5 minutes. It uses a common trading strategy based on Simple Moving Average (SMA) crossovers confirmed by the Relative Strength Index (RSI).
 
 ## Features
 
@@ -61,14 +61,17 @@ The main script is `trading_bot.py`. You can run it from the root directory of t
 python trading_bot.py
 ```
 
-The script will then process the default symbols (`XRPUSDT`, `ADAUSDT`) with the default 1-hour interval and strategy parameters, printing the latest signal for each.
+By default, the bot will now run in a continuous loop, using 5-minute k-line data (`5m` interval by default) and re-evaluating signals every 5 minutes. You will see output in the console for each cycle.
+
+### Stopping the Bot
+To stop the bot, press `Ctrl+C` in the terminal where it is running. The bot is designed to catch this interruption and shut down gracefully.
 
 ### Configuration
 
 You can customize the bot's behavior by modifying the parameters in the `if __name__ == '__main__':` block of `trading_bot.py`:
 
 *   **`symbols`**: A list of trading symbols to process (e.g., `['BTCUSDT', 'ETHUSDT']`).
-*   **`trade_interval`**: The k-line interval for analysis (e.g., `'15m'`, `'4h'`, `'1d'`).
+*   **`trade_interval`**: The k-line interval (candle size) for analysis (e.g., `'5m'`, `'15m'`, `'1h'`, `'1d'`). The default is `'5m'`. During each 5-minute operational cycle, the bot fetches the latest k-lines of this interval to update signals.
 *   **`custom_config`**: A dictionary to override default strategy parameters:
     *   `data_limit`: Number of k-lines to fetch (default: 250).
     *   `sma_short_window`: Period for the short SMA (default: 50).


### PR DESCRIPTION
This commit refactors the trading signal bot to run continuously, evaluating signals every 5 minutes.

Key changes include:

1.  **Modified `run_bot` Function:**
    *   Implemented a `while True` loop to enable continuous operation.
    *   Added `time.sleep(300)` at the end of each cycle to pause for 5 minutes.
    *   Integrated `KeyboardInterrupt` handling for graceful shutdown (Ctrl+C).
    *   Included a general exception handler within the loop for resilience.
    *   Enhanced client initialization with a `ping` test and improved error messages.
    *   Added timestamped console messages for the start of each cycle.

2.  **Updated Default Configuration:**
    *   Changed the default `trade_interval` in the `if __name__ == '__main__':` block to `'5m'` to align the k-line data interval with the 5-minute execution frequency.
    *   Provided comments guiding you on adjusting strategy parameters (like SMA windows) for the shorter 5-minute timeframe if desired.

3.  **Console Output:**
    *   Startup messages are distinct from repeating cycle messages. Timestamps are included for each cycle.

4.  **README.md Update:**
    *   The README now accurately describes the bot's continuous 5-minute operation.
    *   Instructions on how to stop the bot using Ctrl+C have been added.
    *   Clarified the default `trade_interval` and its relation to the 5-minute cycle.

The bot now actively monitors and provides signals at a regular 5-minute interval, making it more suitable for ongoing market observation.